### PR TITLE
Downgrade css-loader dependency for Node 0.10.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "babel-eslint": "^4.1.3",
     "babel-loader": "5.3.2",
     "babel-runtime": "5.8.25",
-		"css-loader": "0.23.0",
+    "css-loader": "0.18.0",
     "eslint": "1.7.3",
     "eslint-plugin-react": "3.6.3",
     "extract-text-webpack-plugin": "^0.9.1",


### PR DESCRIPTION
Running the build task under Node 0.10.x fails with the following error:

> ERROR in ./~/css-loader!./~/sass-loader!./src/components/widget/style.scss
> Module build failed: ReferenceError: Promise is not defined

See webpack/css-loader#144 for details.

I think Node 0.10.x should be supported, because it's the latest version available in the Ubuntu package repository, so it's still widely used in dev environments.

Alternatively, though, the docs could just state that the project requires a current version of Node.
